### PR TITLE
chore: deriveEntrypoint accepts css exports and folder exports

### DIFF
--- a/viteup/src/__tests__/derive-entrypoints.spec.ts
+++ b/viteup/src/__tests__/derive-entrypoints.spec.ts
@@ -565,11 +565,11 @@ describe("deriveEntrypoints", () => {
             "./foo/styles.css": "./dist/foo/styles.css",
             "./ioo/": "./dist/ioo/",
             "./hoo/": "./dist/hoo/",
-          }
-        )
+          },
+        ),
       ).toStrictEqual({
         "src/index.ts": "index",
-        "src/goo/index.ts": "goo/index"
+        "src/goo/index.ts": "goo/index",
       });
     });
   });

--- a/viteup/src/__tests__/derive-entrypoints.spec.ts
+++ b/viteup/src/__tests__/derive-entrypoints.spec.ts
@@ -541,4 +541,36 @@ describe("deriveEntrypoints", () => {
       );
     });
   });
+
+  describe("when provided a standard package.json with multiple type of exports: one export w/ types + default conditions, the package json export, one css export and one folder exports", () => {
+    it("derives exports", () => {
+      expect(
+        deriveEntrypoints(
+          {
+            module: true,
+            outDir: "dist",
+          },
+          {
+            "./package.json": "./package.json",
+            ".": {
+              types: "./dist/index.d.ts",
+              source: "./src/index.ts",
+              default: "./dist/index.mjs",
+            },
+            "./goo": {
+              types: "./dist/goo/index.d.ts",
+              source: "./src/goo/index.ts",
+              default: "./dist/goo/index.mjs",
+            },
+            "./foo/styles.css": "./dist/foo/styles.css",
+            "./ioo/": "./dist/ioo/",
+            "./hoo/": "./dist/hoo/",
+          }
+        )
+      ).toStrictEqual({
+        "src/index.ts": "index",
+        "src/goo/index.ts": "goo/index"
+      });
+    });
+  });
 });

--- a/viteup/src/derive-entrypoints.ts
+++ b/viteup/src/derive-entrypoints.ts
@@ -101,8 +101,8 @@ export function lookupExports(
   for (let [exportPath, conditionalValue] of exportEntries) {
     const skipExportResult = shouldSkipExport(exportPath);
 
-    if(skipExportResult) continue;
-    
+    if (skipExportResult) continue;
+
     if (typeof conditionalValue === "string") {
       conditionalValue = { default: conditionalValue };
     }

--- a/viteup/src/derive-entrypoints.ts
+++ b/viteup/src/derive-entrypoints.ts
@@ -12,6 +12,7 @@ import {
   SUPPORTED_SOURCE_FILES_EXTENSIONS,
 } from "./types.ts";
 import { matchSourceFile } from "./match-source-files.ts";
+import { shouldSkipExport } from "./utils.ts";
 
 export function deriveEntrypoint(
   outDir: string,
@@ -98,8 +99,10 @@ export function lookupExports(
   const exportEntries = Object.entries(exports);
 
   for (let [exportPath, conditionalValue] of exportEntries) {
-    if (exportPath.endsWith(".json")) continue;
+    const skipExportResult = shouldSkipExport(exportPath);
 
+    if(skipExportResult) continue;
+    
     if (typeof conditionalValue === "string") {
       conditionalValue = { default: conditionalValue };
     }

--- a/viteup/src/derive-output-config.ts
+++ b/viteup/src/derive-output-config.ts
@@ -14,7 +14,7 @@ import {
   type DerivedOutputConfig,
   type OutputConfigInit,
 } from "./types.ts";
-import { isObject } from "./utils.ts";
+import { isObject, shouldSkipExport } from "./utils.ts";
 
 function getModuleFormatForCondition(
   packageType: PackageType,
@@ -149,8 +149,9 @@ export function lookupExports(
   }
 
   for (let [exportPath, conditionalValue] of Object.entries(exports)) {
-    if (exportPath.endsWith(".json")) continue;
-    if (exportPath.endsWith(".css")) continue;
+    const skipExportResult = shouldSkipExport(exportPath);
+
+    if(skipExportResult) continue;
 
     if (typeof conditionalValue === "string") {
       conditionalValue = { default: conditionalValue };
@@ -158,7 +159,7 @@ export function lookupExports(
 
     if (!isConditionalValueObject(conditionalValue)) {
       throw new Error(
-        `Package export "${exportPath}" does not include a valid conditional value`,
+        `Package export "${exportPath}" does not include a valid conditional value`
       );
     }
 

--- a/viteup/src/derive-output-config.ts
+++ b/viteup/src/derive-output-config.ts
@@ -151,7 +151,7 @@ export function lookupExports(
   for (let [exportPath, conditionalValue] of Object.entries(exports)) {
     const skipExportResult = shouldSkipExport(exportPath);
 
-    if(skipExportResult) continue;
+    if (skipExportResult) continue;
 
     if (typeof conditionalValue === "string") {
       conditionalValue = { default: conditionalValue };
@@ -159,7 +159,7 @@ export function lookupExports(
 
     if (!isConditionalValueObject(conditionalValue)) {
       throw new Error(
-        `Package export "${exportPath}" does not include a valid conditional value`
+        `Package export "${exportPath}" does not include a valid conditional value`,
       );
     }
 

--- a/viteup/src/utils.ts
+++ b/viteup/src/utils.ts
@@ -1,3 +1,20 @@
+import { SUPPORTED_EXPORT_CONDITIONS } from "./types";
+
 export function isObject(obj: unknown) {
   return typeof obj === "object" && obj !== null;
+}
+
+export function shouldSkipExport(exportPath:string){
+  const bar = exportPath.split(/^\.?\//, 2);
+  if(bar[1] && bar[1].indexOf(".") == -1 ){
+    // check directory
+    if(exportPath.slice(-1) == "/") {
+      return true;
+    } 
+  }else if(exportPath !== "."){
+    if (SUPPORTED_EXPORT_CONDITIONS.some((ext) => !exportPath.endsWith(ext))) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/viteup/src/utils.ts
+++ b/viteup/src/utils.ts
@@ -4,14 +4,14 @@ export function isObject(obj: unknown) {
   return typeof obj === "object" && obj !== null;
 }
 
-export function shouldSkipExport(exportPath:string){
+export function shouldSkipExport(exportPath: string) {
   const bar = exportPath.split(/^\.?\//, 2);
-  if(bar[1] && bar[1].indexOf(".") == -1 ){
+  if (bar[1] && bar[1].indexOf(".") === -1) {
     // check directory
-    if(exportPath.slice(-1) == "/") {
+    if (exportPath.slice(-1) === "/") {
       return true;
-    } 
-  }else if(exportPath !== "."){
+    }
+  } else if (exportPath !== ".") {
     if (SUPPORTED_EXPORT_CONDITIONS.some((ext) => !exportPath.endsWith(ext))) {
       return true;
     }


### PR DESCRIPTION
This PR introduces enhanced flexibility in how Viteup reads export points for consumer projects. 
Specifically:
- Expands support for export points beyond existing JS/TS and JSON extensions
- Improves compatibility with various file types and directory configurations

While this PR allows Viteup to recognize these additional export points, it currently doesn't treat them accordingly. The next step would be to complete this support and compatibility by implementing proper handling for these newly recognized export types.